### PR TITLE
TL-UL: fixed support for uncached Get data scoreboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,26 @@ coupledL2-verilog-clean:
 	$(MAKE) -C ./dut/CoupledL2 clean
 
 
+VERILATOR := verilator
+VERILATOR_COMMON_ARGS := ./dut/CoupledL2/build/*.v \
+		--Mdir ./verilated \
+		-O3 \
+		--trace-fst \
+		--top TestTop \
+		--build-jobs $(THREADS_BUILD) --verilate-jobs $(THREADS_BUILD) \
+		-DSIM_TOP_MODULE_NAME=TestTop \
+		-Wno-fatal
+
+coupledL2-verilate-cc:
+	rm -rf verilated
+	mkdir verilated
+	$(VERILATOR) $(VERILATOR_COMMON_ARGS) --cc
+
+coupledL2-verilate-build:
+	$(VERILATOR) $(VERILATOR_COMMON_ARGS) --cc --exe --build -o tltest_v3lt \
+		libtltest_v3lt.a \
+		-LDFLAGS "-lsqlite3 -ldl" -CFLAGS "-rdynamic"
+
 coupledL2-verilate:
 	rm -rf verilated
 	mkdir verilated

--- a/main/Base/TLLocal.hpp
+++ b/main/Base/TLLocal.hpp
@@ -4,6 +4,7 @@
 #define TLC_TEST_TLLOCAL_H
 
 #include <cstdint>
+#include <cstddef>
 
 
 struct TLLocalConfig {
@@ -16,6 +17,11 @@ public:
 
     uint64_t            ariInterval;                        // Auto Range Iteration interval
     uint64_t            ariTarget;                          // Auto Range Iteration target
+
+public:
+    size_t                          GetAgentCount() const noexcept;
+    size_t                          GetCAgentCount() const noexcept;
+    size_t                          GetULAgentCount() const noexcept;
 };
 
 
@@ -27,7 +33,40 @@ public:
 
     virtual const TLLocalConfig&    config() const noexcept = 0;
     virtual TLLocalConfig&          config() noexcept = 0;
+
+    size_t                          GetAgentCount() const noexcept;
+    size_t                          GetCAgentCount() const noexcept;
+    size_t                          GetULAgentCount() const noexcept;
 };
 
+inline size_t TLLocalConfig::GetCAgentCount() const noexcept
+{
+    return coreCount * masterCountPerCoreTLC;
+}
+
+inline size_t TLLocalConfig::GetULAgentCount() const noexcept
+{
+    return coreCount * masterCountPerCoreTLUL;
+}
+
+inline size_t TLLocalConfig::GetAgentCount() const noexcept
+{
+    return GetCAgentCount() + GetULAgentCount();
+}
+
+inline size_t TLLocalContext::GetCAgentCount() const noexcept
+{
+    return config().GetCAgentCount();
+}
+
+inline size_t TLLocalContext::GetULAgentCount() const noexcept
+{
+    return config().GetULAgentCount();
+}
+
+inline size_t TLLocalContext::GetAgentCount() const noexcept
+{
+    return config().GetAgentCount();
+}
 
 #endif // TLC_TEST_TLLOCAL_H

--- a/main/Sequencer/TLSequencer.hpp
+++ b/main/Sequencer/TLSequencer.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 
 #include "../Utils/ScoreBoard.h"
+#include "../Utils/ULScoreBoard.h"
 #include "../Utils/Common.h"
 #include "../TLAgent/ULAgent.h"
 #include "../TLAgent/CAgent.h"
@@ -54,6 +55,7 @@ private:
     State                   state;
 
     GlobalBoard<paddr_t>*   globalBoard;
+    UncachedBoard<paddr_t>* uncachedBoard;
 
     TLLocalConfig           config;
 

--- a/main/TLAgent/BaseAgent.h
+++ b/main/TLAgent/BaseAgent.h
@@ -7,9 +7,11 @@
 
 #include <set>
 #include <random>
+#include <array>
 #include "Bundle.h"
 #include "../Utils/Common.h"
 #include "../Utils/ScoreBoard.h"
+#include "../Utils/ULScoreBoard.h"
 #include "../Base/TLLocal.hpp"
 
 
@@ -155,11 +157,12 @@ namespace tl_agent {
         using tlport_t = Bundle<ReqField, RespField, EchoField, BEATSIZE>;
 
     protected:
-        TLLocalConfig*          cfg;
-        const int id;
-        tlport_t                *port;
-        GlobalBoard<paddr_t>    *globalBoard;
-        IDPool                  idpool;
+        TLLocalConfig*              cfg;
+        const int                   id;
+        tlport_t*                   port;
+        GlobalBoard<paddr_t>*       globalBoard;
+        UncachedBoard<paddr_t>*     uncachedBoards;
+        IDPool                      idpool;
         virtual void timeout_check() = 0;
 
         const unsigned int      seed;

--- a/main/TLAgent/CAgent.h
+++ b/main/TLAgent/CAgent.h
@@ -98,7 +98,7 @@ namespace tl_agent {
                 Debug(ctx, Append("TL-C local scoreboard update (dirty): ")
                     .ShowBase()
                     .Dec().Append("[alias = ", alias, "]")
-                    .Hex().Append(" dirty = ", PrivilegeToString(dirty))
+                    .Hex().Append(" dirty = ", dirty)
                     .EndLine());
 #           endif
         }
@@ -230,7 +230,7 @@ namespace tl_agent {
         void timeout_check() override;
 
     public:
-        CAgent(TLLocalConfig* cfg, GlobalBoard<paddr_t> * const gb, int id, unsigned int seed, uint64_t* cycles) noexcept;
+        CAgent(TLLocalConfig* cfg, GlobalBoard<paddr_t>* gb, UncachedBoard<paddr_t>* ub, int id, unsigned int seed, uint64_t* cycles) noexcept;
         virtual ~CAgent() noexcept;
 
         uint64_t    cycle() const noexcept override;

--- a/main/TLAgent/ULAgent.cpp
+++ b/main/TLAgent/ULAgent.cpp
@@ -298,10 +298,13 @@ namespace tl_agent {
                 } else if (TLEnumEquals(chnD.opcode, TLOpcodeD::AccessAck)) 
                 { 
                     // finish pending status in GlobalBoard
+                    uncachedBoards->appendAll(this, info->address, 
+                        this->globalBoard->query(this, info->address)->data);
                     this->globalBoard->unpending(this, info->address);
                 }
                 localBoard->erase(this, chnD.source);
-                uncachedBoards->finish(this, id, info->address, pendingD.info->source);
+                if (hasData)
+                    uncachedBoards->finish(this, id, info->address, pendingD.info->source);
                 this->idpool.freeid(chnD.source);
             }
         }

--- a/main/TLAgent/ULAgent.h
+++ b/main/TLAgent/ULAgent.h
@@ -66,7 +66,7 @@ namespace tl_agent {
         void timeout_check() override;
 
     public:
-        ULAgent(TLLocalConfig* cfg, GlobalBoard<paddr_t> * const gb, int id, unsigned int seed, uint64_t* cycles) noexcept;
+        ULAgent(TLLocalConfig* cfg, GlobalBoard<paddr_t>* gb, UncachedBoard<paddr_t>* ub, int id, unsigned int seed, uint64_t* cycles) noexcept;
         virtual ~ULAgent() noexcept;
 
         uint64_t    cycle() const noexcept override;

--- a/main/Utils/ScoreBoard.h
+++ b/main/Utils/ScoreBoard.h
@@ -4,7 +4,7 @@
 
 #include <cstddef>
 #include <iterator>
-#include <map>
+#include <unordered_map>
 #include <array>
 #include <memory>
 #include <type_traits>
@@ -104,12 +104,12 @@ template<typename Tk, typename Tv, typename TUpdateCallback = ScoreBoardUpdateCa
 class ScoreBoard {
     friend class ScoreBoardUpdateCallback<Tk, Tv>;
 protected:
-    TUpdateCallback                     updateCallback;
-    std::map<Tk, std::shared_ptr<Tv>>   mapping;
+    TUpdateCallback                             updateCallback;
+    std::unordered_map<Tk, std::shared_ptr<Tv>> mapping;
 public:
     ScoreBoard();
     ~ScoreBoard();
-    std::map<Tk, std::shared_ptr<Tv>>& get();
+    std::unordered_map<Tk, std::shared_ptr<Tv>>& get();
     void update(const TLLocalContext* ctx,const Tk& key, std::shared_ptr<Tv>& data);
     std::shared_ptr<Tv> query(const TLLocalContext* ctx, const Tk& key);
     void erase(const TLLocalContext* ctx, const Tk& key);
@@ -166,8 +166,8 @@ struct ScoreBoardUpdateCallbackGlobalEntry : public ScoreBoardUpdateCallback<Tk,
             std::cout << std::endl;
 
             std::cout << "data - pend : ";
-            if (data->data != nullptr)
-                data_dump<DATASIZE>(data->data->data);
+            if (data->pending_data != nullptr)
+                data_dump<DATASIZE>(data->pending_data->data);
             else
                 std::cout << "<non-initialized>";
             std::cout << std::endl;
@@ -199,7 +199,7 @@ ScoreBoard<Tk, Tv, TUpdateCallback>::~ScoreBoard() {
 }
 
 template<typename Tk, typename Tv, typename TUpdateCallback>
-std::map<Tk, std::shared_ptr<Tv>>& ScoreBoard<Tk, Tv, TUpdateCallback>::get() {
+std::unordered_map<Tk, std::shared_ptr<Tv>>& ScoreBoard<Tk, Tv, TUpdateCallback>::get() {
     return this->mapping;
 }
 

--- a/main/Utils/ULScoreBoard.h
+++ b/main/Utils/ULScoreBoard.h
@@ -1,0 +1,337 @@
+#pragma once
+
+#include "Common.h"
+#include "ScoreBoard.h"
+#include "gravity_utility.hpp"
+
+#ifndef TLC_TEST_ULSCOREBOARD_H
+#define TLC_TEST_ULSCOREBOARD_H
+
+
+template<std::size_t N>
+inline void data_dump_multiple_on_verify(const uint8_t* dut, const std::vector<shared_tldata_t<N>>& ref)
+{
+    std::cout << std::endl;
+
+    std::cout << "DUT [    ]: ";
+    data_dump<N>(dut);
+    std::cout << std::endl;
+
+    for (int i = 0; i < ref.size(); i++)
+    {
+        std::cout << "REF [" 
+            << Gravity::StringAppender().Dec().NextWidth(4).Right().Append(i).ToString() 
+            << "]: ";
+        data_dump<N>(ref[i]->data);
+        std::cout << std::endl;
+    }
+}
+
+template<>
+struct std::hash<std::array<paddr_t, 2>> {
+    auto operator()(const std::array<paddr_t, 2>& key) const {
+        return key[0] ^ key[1];
+    }
+};
+
+/*
+* *NOTICE: All corresponding data between Get and AccessAckData was recorded and allowed.
+*/
+template<typename Tk, typename Tv>
+struct ULScoreBoardCallback {
+    void    allocate(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, std::shared_ptr<Tv> data) {};
+    void    append  (const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, std::shared_ptr<Tv> data) {};
+    void    finish  (const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source) {};
+};
+
+template<typename Tk, typename Tv>
+struct ULScoreBoardCallbackDefault : public ULScoreBoardCallback<Tk, Tv> {
+    void    allocate(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, std::shared_ptr<Tv> data) {};
+    void    append  (const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, std::shared_ptr<Tv> data, int ordinal) {};
+    void    finish  (const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source) {};
+};
+
+template<typename Tk, typename Tv, typename TCallback = ULScoreBoardCallbackDefault<Tk, Tv>>
+class ULScoreBoard {
+    friend class ULScoreBoardCallback<Tk, Tv>;
+protected:
+    TCallback                                                   callback;
+    size_t                                                      count;
+    std::unordered_map<Tk, std::unordered_map<uint32_t, std::vector<std::shared_ptr<Tv>>>>*   mapping;
+public:
+    ULScoreBoard(size_t ulAgentCount);
+    ~ULScoreBoard();
+    void    allocate    (const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, std::shared_ptr<Tv> data);
+    void    append      (const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source,std::shared_ptr<Tv> data);
+    void    appendAll   (const TLLocalContext* ctx, const Tk& key, std::shared_ptr<Tv>& data);
+    void    finish      (const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source);
+    int     verify      (size_t sysId, const Tk& key, uint32_t source, const Tv& data) const;
+    bool    haskey      (size_t sysId, const Tk& key, uint32_t source);
+};
+
+template<typename Tk>
+struct ULScoreBoardCallbackTLData : public ULScoreBoardCallback<Tk, wrapped_tldata_t<DATASIZE>> {
+    void    allocate(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, shared_tldata_t<DATASIZE> data);
+    void    append  (const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, shared_tldata_t<DATASIZE> data, int ordinal);
+    void    finish  (const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source);
+};
+
+template<typename Tk>
+class UncachedBoard : public ULScoreBoard<Tk, wrapped_tldata_t<DATASIZE>, ULScoreBoardCallbackTLData<Tk>> {
+private:
+    bool data_check(TLLocalContext* ctx, const uint8_t* dut, const uint8_t* ref);
+    shared_tldata_t<DATASIZE>   init_zeros;
+public:
+    UncachedBoard(size_t ulAgentCount) noexcept;
+    void    allocateZero(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source);
+    int     verify(TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, shared_tldata_t<DATASIZE> data);
+};
+
+
+/************************** Implementation **************************/
+template<typename Tk>
+void ULScoreBoardCallbackTLData<Tk>::allocate(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, shared_tldata_t<DATASIZE> data)
+{
+#   if SB_DEBUG == 1
+        Gravity::StringAppender strapp("Uncached ScoreBoard: ");
+
+        strapp.Append("action = allocate")
+            .Dec().Append(", index = ", sysId)
+            .ShowBase()
+            .Hex().Append(", source = ", source)
+            .Hex().Append(", key = ", uint64_t(key))
+            .EndLine();
+
+        Debug(ctx, Append(strapp.ToString()));
+
+        std::cout << "data[0]: ";
+        if (data != nullptr)
+            data_dump<DATASIZE>(data->data);
+        else
+            std::cout << "<non-initialized>";
+        std::cout << std::endl;
+#   endif
+}
+
+template<typename Tk>
+void ULScoreBoardCallbackTLData<Tk>::append(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, shared_tldata_t<DATASIZE> data, int ordinal)
+{
+#   if SB_DEBUG == 1
+        Gravity::StringAppender strapp("Uncached ScoreBoard: ");
+
+        strapp.Append("action = append")
+            .Dec().Append(", index = ", sysId)
+            .ShowBase()
+            .Hex().Append(", source = ", source)
+            .Hex().Append(", key = ", uint64_t(key))
+            .EndLine();
+
+        Debug(ctx, Append(strapp.ToString()));
+
+        std::cout << "data[" << ordinal << "]: ";
+        if (data != nullptr)
+            data_dump<DATASIZE>(data->data);
+        else
+            std::cout << "<non-initialized>";
+        std::cout << std::endl;
+#   endif
+}
+
+template<typename Tk>
+void ULScoreBoardCallbackTLData<Tk>::finish(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source)
+{
+#   if SB_DEBUG == 1
+        Gravity::StringAppender strapp("Uncached ScoreBoard: ");
+
+        strapp.Append("action = finish")
+            .Dec().Append(", index = ", sysId)
+            .ShowBase()
+            .Hex().Append(", source = ", source)
+            .Hex().Append(", key = ", uint64_t(key))
+            .EndLine();
+        
+        Debug(ctx, Append(strapp.ToString()));
+#   endif
+}
+
+
+/************************** Implementation **************************/
+template<typename Tk, typename Tv, typename TUpdateCallback>
+ULScoreBoard<Tk, Tv, TUpdateCallback>::ULScoreBoard(size_t ulAgentCount)
+{
+    count   = ulAgentCount;
+    mapping = new std::unordered_map<Tk, std::unordered_map<uint32_t, std::vector<std::shared_ptr<Tv>>>>[ulAgentCount];
+}
+
+template<typename Tk, typename Tv, typename TUpdateCallback>
+ULScoreBoard<Tk, Tv, TUpdateCallback>::~ULScoreBoard()
+{
+    delete[] mapping;
+}
+
+template<typename Tk, typename Tv, typename TUpdateCallback>
+void ULScoreBoard<Tk, Tv, TUpdateCallback>::allocate(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, std::shared_ptr<Tv> data)
+{
+    if (mapping[sysId].count(key) != 0 && mapping[sysId][key].count(source) != 0)
+        tlc_assert(false, ctx, Gravity::StringAppender()
+            .Append("duplicated uncached scoreboard entry allocation ")
+            .Append("at ", sysId)
+            .ToString());
+    else
+    {
+        if (mapping[sysId].count(key) == 0)
+            mapping[sysId].insert(std::make_pair(key, std::unordered_map<uint32_t, std::vector<shared_tldata_t<DATASIZE>>>()));
+
+        mapping[sysId][key].insert(std::make_pair(source, std::vector<shared_tldata_t<DATASIZE>>()));
+
+        mapping[sysId][key][source].push_back(data);
+    }
+
+    callback.allocate(ctx, sysId, key, source, data);
+}
+
+template<typename Tk, typename Tv, typename TUpdateCallback>
+void ULScoreBoard<Tk, Tv, TUpdateCallback>::append(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, std::shared_ptr<Tv> data)
+{
+    int ordinal = 0;
+    if (mapping[sysId].count(key) != 0)
+    {
+        std::unordered_map<uint32_t, std::vector<std::shared_ptr<Tv>>>& sources = mapping[sysId][key];
+        if (sources.count(source) != 0)
+        {
+            std::vector<std::shared_ptr<Tv>>& entry = sources[source];
+            ordinal = entry.size();
+            entry.push_back(data);
+        }
+        else
+        {
+            tlc_assert(false, ctx, Gravity::StringAppender()
+            .Append("append on non-allocated scoreboard entry ")
+            .Append("at ", sysId)
+            .Append(" with source ", source)
+            .ToString());
+        }
+    }
+    else
+        tlc_assert(false, ctx, Gravity::StringAppender()
+            .Append("append on non-allocated scoreboard entry ")
+            .Append("at ", sysId)
+            .ToString());
+    
+    callback.append(ctx, sysId, key, source, data, ordinal);
+}
+
+template<typename Tk, typename Tv, typename TUpdateCallback>
+void ULScoreBoard<Tk, Tv, TUpdateCallback>::appendAll(const TLLocalContext* ctx, const Tk& key, std::shared_ptr<Tv>& data)
+{
+    for (size_t sysId = 0; sysId < count; sysId++)
+    {
+        if (mapping[sysId].count(key) != 0)
+        {
+            std::unordered_map<uint32_t, std::vector<std::shared_ptr<Tv>>>& sources = mapping[sysId][key];
+            for (auto iter = sources.begin(); iter != sources.end(); iter++)
+            {
+                int ordinal = iter->second.size();
+                iter->second.push_back(data);
+                callback.append(ctx, sysId, key, iter->first, data, ordinal);
+            }
+        }
+        else
+            continue;
+    }
+}
+
+template<typename Tk, typename Tv, typename TUpdateCallback>
+void ULScoreBoard<Tk, Tv, TUpdateCallback>::finish(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source)
+{
+    tlc_assert(mapping[sysId].count(key) == 1, ctx, Gravity::StringAppender()
+        .Append("no or multiple uncached scoreboard entry mapped ")
+        .Append("at ", sysId)
+        .ToString());
+
+    tlc_assert(mapping[sysId][key].count(source) == 1, ctx, Gravity::StringAppender()
+        .Append("no or multiple uncached scoreboard entry mapped ")
+        .Append("at ", sysId)
+        .Append(" with source ", source)
+        .ToString());
+
+    mapping[sysId][key].erase(source);
+
+    if (mapping[sysId][key].empty())
+        mapping[sysId].erase(key);
+}
+
+template<typename Tk, typename Tv, typename TUpdateCallback>
+int ULScoreBoard<Tk, Tv, TUpdateCallback>::verify(size_t sysId, const Tk& key, uint32_t source, const Tv& data) const
+{
+    if (mapping[sysId].count(key) > 0)
+    {
+        if (mapping[sysId][key][source] > 0)
+        {
+            if (*mapping[sysId][key][source] != data)
+                return ERR_MISMATCH;
+        }
+        else
+            return ERR_NOTFOUND;
+
+        return 0;
+    }
+
+    return ERR_NOTFOUND;
+}
+
+template<typename Tk, typename Tv, typename TUpdateCallback>
+bool ULScoreBoard<Tk, Tv, TUpdateCallback>::haskey(size_t sysId, const Tk& key, uint32_t source)
+{
+    return mapping[sysId].count(key) > 0 && mapping[sysId][key].count(source) > 0;
+}
+
+template<typename Tk>
+UncachedBoard<Tk>::UncachedBoard(size_t ulAgentCount) noexcept
+    : ULScoreBoard<Tk, wrapped_tldata_t<DATASIZE>, ULScoreBoardCallbackTLData<Tk>>(ulAgentCount)
+{
+    init_zeros = make_shared_tldata<DATASIZE>();
+    std::memset(init_zeros->data, 0, DATASIZE);
+}
+
+template<typename Tk>
+void UncachedBoard<Tk>::allocateZero(const TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source)
+{
+    this->allocate(ctx, sysId, key, source, init_zeros);
+}
+
+template<typename Tk>
+bool UncachedBoard<Tk>::data_check(TLLocalContext* ctx, const uint8_t *dut, const uint8_t *ref)
+{
+    for (int i = 0; i < DATASIZE; i++)
+        if (dut[i] != ref[i])
+            return false;
+    
+    return true;
+}
+
+template<typename Tk>
+int UncachedBoard<Tk>::verify(TLLocalContext* ctx, size_t sysId, const Tk& key, uint32_t source, shared_tldata_t<DATASIZE> data)
+{
+    if (this->mapping[sysId].count(key) == 0 || this->mapping[sysId][key].count(source) == 0)
+        tlc_assert(false, ctx, "non-exist data verify action");
+
+    bool hit = false;
+    std::vector<shared_tldata_t<DATASIZE>> entry = this->mapping[sysId][key][source];
+    for (auto ref : entry)
+        if (data_check(ctx, data->data, ref->data))
+        {
+            hit = true;
+            break;
+        }
+
+    if (!hit)
+    {
+        data_dump_multiple_on_verify<DATASIZE>(data->data, entry);
+        tlc_assert(false, ctx, "Data mismatch");
+    }
+
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
* Added individual UL-Scoreboard for every agent port.

* Changed the implementation of scoreboard from 'map'
to 'unordered_map' for better performance.

* Update UL-Scoreboard for any corresponding records
on dirty 'ReleaseData' and 'ProbeAckData' in CAgent.

* Update UL-Scoreboard for any corresponding records
on 'PutPartialData' and 'PutFullData' in ULAgent.

* Allocate UL-Scoreboard records on 'Get' and free
records on 'AccessAckData'.

* Implementing UL-Scoreboard with two-level map for
supporting of sending inflight 'Get's with the same
address on a single UL-Agent port.