### PR TITLE
fix(CMakeLists.txt): detect Verilator include path dynamically

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -34,7 +34,14 @@ if (NOT DEFINED CHISELDB_PATH)
 endif ()
 
 if (NOT DEFINED VERILATOR_INCLUDE)
-    SET(VERILATOR_INCLUDE "/usr/local/share/verilator/include")
+    execute_process(
+        COMMAND verilator --getenv VERILATOR_ROOT
+        OUTPUT_VARIABLE VERILATOR_ROOT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
+
+    set(VERILATOR_INCLUDE "${VERILATOR_ROOT}/include")
 endif ()
 
 if (NOT DEFINED VERILATED_PATH)


### PR DESCRIPTION
Detect Verilator include path dynamically to prevent forgetting to set the VERILATOR_INCLUDE when using a self-compiled verilator